### PR TITLE
feat: add client api key support

### DIFF
--- a/src/CoinGeckoClient.test.ts
+++ b/src/CoinGeckoClient.test.ts
@@ -9,6 +9,12 @@ describe('CoinGeckoClient test', () => {
     expect(ping).toEqual({ gecko_says: '(V3) To the Moon!' });
   });
 
+  it('ping for pro API should also be successful', async () => {
+    const proClient = new CoinGeckoClient({ apiKey: 'xxx' });
+    const ping: any = (await proClient.ping());
+    expect(ping.status.error_message).toEqual('API Key Missing');
+  });
+
   it('/search/trending should successful', async () => {
     const trending = await client.trending();
     expect(trending.coins?.length).toBeGreaterThan(1);

--- a/src/CoinGeckoClient.ts
+++ b/src/CoinGeckoClient.ts
@@ -33,6 +33,8 @@ import {
 export class CoinGeckoClient {
   apiV3Url = 'https://api.coingecko.com/api/v3'
 
+  apiV3UrlPro = 'http://pro-api.coingecko.com/api/v3'
+
   options: Options = {
     timeout: 30000,
     autoRetry: true,
@@ -70,6 +72,14 @@ export class CoinGeckoClient {
       },
       timeout: this.options.timeout, // in ms
     };
+
+    if (this.options.apiKey) {
+      options.headers = {
+        ...options.headers,
+        x_cg_pro_api_key: this.options.apiKey,
+      } as any;
+    }
+
     const parseJson = (input: string) => {
       try {
         return JSON.parse(input);
@@ -122,7 +132,8 @@ export class CoinGeckoClient {
    */
   private async makeRequest<T>(action: API_ROUTES, params: { [key: string]: any } = {}): Promise<T> {
     const qs = Object.entries(params).map(([key, value]) => `${key}=${value}`).join('&');
-    const requestUrl = `${this.apiV3Url + this.withPathParams(action, params)}?${qs}`;
+    const baseUrl = this.options.apiKey ? this.apiV3UrlPro : this.apiV3Url;
+    const requestUrl = `${baseUrl + this.withPathParams(action, params)}?${qs}`;
     const res = await this.httpGet<T>(requestUrl);// await this.http.get<T>(requestUrl);
     if (res.statusCode === 429 && this.options.autoRetry) {
       await new Promise((r) => setTimeout(r, 2000));

--- a/src/Inteface.ts
+++ b/src/Inteface.ts
@@ -519,7 +519,8 @@ export type GlobalDefiResponse = ResponseWithData<GlobalDefiData>;
 
 export interface Options {
   timeout?: number,
-  autoRetry?: boolean
+  autoRetry?: boolean,
+  apiKey?: string,
 }
 
 export interface HttpResponse<T> {


### PR DESCRIPTION
Making our version of `coingeck-api-v3` lib on top of the original lib, because original lib is not supporting the pro mode